### PR TITLE
Improve usuarios.txt mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ A Ludopedia utiliza o BGG como insumo para sua base de dados, mas não possui ne
 
 ### Marcando amigos na importação de partidas
 
-Não tendo uma forma automática de identificar outros usuários do BGG na Ludopedia, para marcar amigos nas partidas, uma possibilidade é criar um arquivo `usuarios.txt` neste mesmo diretório, tendo como conteúdo um usuário por linha, no formato `nome_usuario_bgg=id_usuario_ludopedia`.
+Não tendo uma forma automática de identificar outros usuários do BGG na Ludopedia, para marcar amigos nas partidas, uma possibilidade é criar um arquivo `usuarios.txt` neste mesmo diretório, tendo como conteúdo um usuário por linha, no formato `nome_usuario_bgg=id_usuario_ludopedia` ou `nome_usuario_bgg=nome_usuario_ludopedia`. Exemplo:
+
+```
+fulano=ciclano
+beltrano=12345
+```
 
 ### Problemas, dúvidas ou sugestões?
 


### PR DESCRIPTION
This makes it a bit easier and safer to use the user mapping when logging plays. Each commit has its own explanation, but here they are abridged:

fd3d691 - This allows users of the app to fill the "usuarios.txt" file with just usernames of both bgg and ludopedia, and the app will find the equivalent ludopedia user id automatically, being a bit more user friendly
22de883 - Make sure that user provided only valid BGG usernames on the usuarios.txt file