### PR TITLE
Fix Ludopedia URL not using 'www' anymore and other small fixes

### DIFF
--- a/importador.py
+++ b/importador.py
@@ -33,7 +33,7 @@ BGG_USER_API = f'{BGG_API}user'
 BGG_PLAYS_PER_PAGE = int(100)
 
 # Ludopedia constants
-LUDOPEDIA_URL = 'https://www.ludopedia.com.br/'
+LUDOPEDIA_URL = 'https://ludopedia.com.br/'
 LUDOPEDIA_ADD_GAME_URL = f'{LUDOPEDIA_URL}classes/jogo_usuario_ajax.php'
 LUDOPEDIA_ADD_PLAY_URL = f'{LUDOPEDIA_URL}cadastra_partida'
 LUDOPEDIA_LOGIN_URL = f'{LUDOPEDIA_URL}login'

--- a/importador.py
+++ b/importador.py
@@ -480,7 +480,7 @@ class PlayTableModel(QAbstractItemModel):
         if column == 6:
             return play.comments
         return None
-    
+
     def get_alignment(self, column):
         """Returns preferred text alignment for each column"""
         if column == 1 or column == 2:
@@ -867,7 +867,7 @@ class LudopediaPlayLogger(GenericWorker):
                     imported_plays += 1
                 else:
                     self.post_error(f'Erro ao postar partida #{bgg_play.id}'
-                                    f'de {bgg_play.game_name}')
+                                    f' de {bgg_play.game_name}')
 
             else:
                 self.post_error(f'Jogo não encontrado na Ludopedia: {bgg_play.game_name}')


### PR DESCRIPTION
This is a simple PR with 3 commits:

1. Change Ludopedia's URL to not have leading 'www' anymore, so that it starts finding the pattern for the play id again
2. Fix a case where program could crash when not retrieving any play
3. Small whitespace and formatting fixes

PS: Yes, the script has been working for the last year or so flawlessly and I've been using it diligently to sync my BGG plays over to Ludopedia :)